### PR TITLE
docs: add default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,31 @@
+---
+name: Default issue
+about: Report a bug, request an enhancement, or propose an improvement.
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Summary
+
+Describe the issue or proposal in one or two sentences.
+
+## Motivation
+
+Why is this worth doing? What problem does it solve or what value does it add?
+
+## Definition of done
+
+What should be true when this is complete?
+
+## Proposed approach
+
+Share your implementation idea, suggested direction, or any constraints to keep in mind.
+
+## Additional context
+
+Add screenshots, examples, related discussions, or anything else that would help.
+
+## Related issues
+
+Link any related issues or pull requests.


### PR DESCRIPTION
Closes #1

## Summary
- add a default GitHub issue template
- cover the sections requested in the issue
- give contributors a clearer structure for new reports and proposals

## Testing
- not run, docs-only GitHub metadata change